### PR TITLE
Expose the sha from pull_request_files and the build head branch

### DIFF
--- a/lib/policial/commit_file.rb
+++ b/lib/policial/commit_file.rb
@@ -10,6 +10,10 @@ module Policial
       @commit = commit
     end
 
+    def sha
+      @file.sha
+    end
+
     def filename
       @file.filename
     end

--- a/lib/policial/pull_request.rb
+++ b/lib/policial/pull_request.rb
@@ -6,10 +6,11 @@ module Policial
     attr_reader :repo, :number, :user
     attr_accessor :github_client
 
-    def initialize(repo:, number:, head_sha:, github_client:, user: nil)
+    def initialize(repo:, number:, head_sha:, head_ref:, github_client:, user: nil)
       @repo = repo
       @number = number
       @head_sha = head_sha
+      @head_ref = head_ref
       @user = user
       @github_client = github_client
     end

--- a/lib/policial/pull_request_event.rb
+++ b/lib/policial/pull_request_event.rb
@@ -16,6 +16,7 @@ module Policial
         repo: @payload['repository']['full_name'],
         number: @payload['number'],
         head_sha: @payload['pull_request']['head']['sha'],
+        head_ref: @payload['pull_request']['head']['ref'],
         user: @payload['pull_request']['user']['login']
       }
     rescue NoMethodError

--- a/spec/commit_file_spec.rb
+++ b/spec/commit_file_spec.rb
@@ -61,8 +61,16 @@ describe Policial::CommitFile do
     end
   end
 
+  describe '#sha' do
+    it 'returns the github file sha' do
+      commit_file = commit_file(status: 'modified')
+
+      expect(commit_file.sha).to eq 'abc289171'
+    end
+  end
+
   def commit_file(options = {})
-    file = double(:file, { patch: '', filename: 'test.rb' }.merge(options))
+    file = double(:file, { patch: '', sha: 'abc289171', filename: 'test.rb' }.merge(options))
     commit = double(
       :commit,
       repo_name: 'test/test',

--- a/spec/detective_spec.rb
+++ b/spec/detective_spec.rb
@@ -25,7 +25,8 @@ describe Policial::Detective do
         repo: 'volmer/policial',
         number: 666,
         user: 'rafaelfranca',
-        head_sha: '123abc'
+        head_sha: '123abc',
+        head_ref: 'my-branch'
       )
 
       expect(subject.pull_request.repo).to eq('volmer/policial')

--- a/spec/pull_request_event_spec.rb
+++ b/spec/pull_request_event_spec.rb
@@ -20,6 +20,7 @@ describe Policial::PullRequestEvent do
       expect(attributes[:head_sha]).to eq(
         '498b81cd038f8a3ac02f035a8537b7ddcff38a81'
       )
+      expect(attributes[:head_ref]).to eq('another-test')
       expect(attributes[:user]).to eq('volmerius')
     end
 

--- a/spec/pull_request_spec.rb
+++ b/spec/pull_request_spec.rb
@@ -8,6 +8,7 @@ describe Policial::PullRequest do
       repo: 'volmer/cerberus',
       number:  45,
       head_sha: 'commitsha',
+      head_ref: 'my-branch',
       user: 'volmerius',
       github_client: Octokit
     )


### PR DESCRIPTION
This is necessary for https://github.com/Shopify/policial.io/pull/222

* Adds the file sha from this api call: https://developer.github.com/v3/pulls/#list-pull-requests-files
* Adds the head ref (the branch name) from the pull request event payload

cc @etiennebarrie @rafaelfranca 